### PR TITLE
rl_isdir: exception if list is non-existent

### DIFF
--- a/src/reportlab/lib/utils.py
+++ b/src/reportlab/lib/utils.py
@@ -692,7 +692,10 @@ def rl_isdir(pn,os_path_isdir=os.path.isdir,os_path_normpath=os.path.normpath):
     if _isFSD or __loader__ is None: return False
     pn = _startswith_rl(os_path_normpath(pn))
     if not pn.endswith(os.sep): pn += os.sep
-    return len(list(filter(lambda x,pn=pn: x.startswith(pn),list(__loader__._files.keys()))))>0
+    try:
+        return len(list(filter(lambda x,pn=pn: x.startswith(pn),list(__loader__._files.keys()))))>0
+    except AttributeError:
+        return False
 
 def rl_listdir(pn,os_path_isdir=os.path.isdir,os_path_normpath=os.path.normpath,os_listdir=os.listdir):
     if os_path_isdir(pn) or _isFSD or __loader__ is None: return os_listdir(pn)


### PR DESCRIPTION
I got error by packaging my reportlab project.
Using this small change I could package my project.