### PR TITLE
temporary FIX: drawToPMCanvas -> dpi ignored

### DIFF
--- a/src/reportlab/graphics/renderPM.py
+++ b/src/reportlab/graphics/renderPM.py
@@ -638,6 +638,8 @@ class PMCanvas:
 
 def drawToPMCanvas(d, dpi=72, bg=0xffffff, configPIL=None, showBoundary=rl_config._unset_):
     d = renderScaledDrawing(d)
+    scale = dpi/72.0
+    d.scale(scale,scale)
     c = PMCanvas(d.width, d.height, dpi=dpi, bg=bg, configPIL=configPIL)
     draw(d, c, 0, 0, showBoundary=showBoundary)
     return c


### PR DESCRIPTION
Hi there,

when creating a raster image from an SVG with dpi values different then 72, the image range is scaled,  but not the image itself.

Version used: 0.8.1

Minimum working example:

`
import numpy as np
from lxml import etree
from svglib.svglib import SvgRenderer
from reportlab.graphics import renderPM
import pylab as plt

s = ''' <svg 
xmlns:dc="http://purl.org/dc/elements/1.1/"
xmlns:cc="http://creativecommons.org/ns#"
xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
xmlns:svg="http://www.w3.org/2000/svg"
xmlns="http://www.w3.org/2000/svg"
xmlns:xlink="http://www.w3.org/1999/xlink"
version="1.1"

width="100mm"
height="100mm" >

<image 
    x="0mm" y="27mm" 
    width="45mm" height="45mm" 
    xlink:href="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAAtAC0DASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD8cPBuvNrkzQrbOuTjlCK3NW+CNzr1v9qS7A3jpvArpt3gzwsjSCzVSQccjrXH6r8TJNLv3uTc4t8/KM1/pnVeb5tkFSGb1FFRTc5tWi49l2sfZTyzhnh5QpZlNV3J2UYuzj5vyLupeAZND8IPpzXAZh/tA9qs/BuZdI0KTSZTgyLgE/WueufGF1qER1eW4za9xmp9K1JtWsX1rRH2wxDLY54riw2B4XnXoRr4iKqqF6bv9hdfNCoZxHDZusVltFqMYuLju3F7teVit8cNNGiTxXbShgWVsbqwbL4x21lapam1J2DGdho8VT6r8SLpLaxmLeU4VuM9K3tM+CdzJYxvLbZYjk7a+QpR4szfiHE1MqxkKNLS1WUbwqeUfTqePivreNzGpiMqw8nCXTdrv+J13xttrHT7BTAfmK8fnXnngPwpf6/rxTXov9DJGD1+tel+K7Kw8TwbdXnCbBld3qK5O08RXWjXpsXjK2yfdk7V7maYCvmKo4HGVpQpxd3Z6Tv0n0sfT8QYfL/9Z/7UnBOk7Wiu67rojlfHbLZa23hXRv8AVHOFrW8M2Gp+HPDE9nMm1Wj55pNI0GDX/iDHqCncp7/jXffEXw/Jb2cltaQ7ty4GBXlcN5LVw+aYirj4qUoRnGj1Xs7O2v8AkeTRyytj8Nic1wzcYxk42j59Eux5H4YnvoLyafSOSHYtz781tH4xanYn7LJcgMnBBaqnhbQvEmiy3ITTZNsjNk+xrN1DwXp11ePPcyqrscsCKvJsLxXVyOl/ZVKk53lzQnLljFXduX16nyVTF4zKaacKlSm3vo0n+B6h8aIDolrHLZT7uhIRs965G1v5fG9qugzW5t8cecy7evvWpqV3capIkd9IZBuAw1avxM02y0T4dR6jpcAhmKtl1616/H2TZlkmVKvXr89N35opWbXa/Q+5wtejxHmmMx2Hj7OlTgnKD1uuyfQZ4P0Kw8I3KFr+ORk7mQGu0m8QWGqyq7PGfY182WHifXZbgGTUHP411eh65qjSoDeN1rn4Rz3B8UUKdOnScPZrkV3fQ4sBxxRyanLD0KNqcpXav1PUPG/jq08M2rRWmkpLvTGUhzjNeK6xrtxe6lLdCJk3tnbtIxXtXhGxtda02VtThEpERwW+leY+I9Os49ZnRIQAH4ArpxPDmYvNatHD4jkUbdO5fHuMxuPyzC46rJezm3yxsk42316n/9k="/>
<text 
    x="22.5mm" y="50mm" 
    font-family="sans-serif" 
    font-size="4.666666666666667mm" fill="black">aaaaa</text>
<text 
    x="77.5mm" y="50mm" 
    font-family="sans-serif" 
    font-size="4.666666666666667mm" fill="black">bbb</text>
</svg>'''.encode('UTF-8')

parser = etree.XMLParser(remove_comments=True, recover=True)
xml = etree.fromstring(s, parser=parser)

for dpi in  (72, 150, 300):
    drw = SvgRenderer('_tempfile.svg').render(xml)
    pil = renderPM.drawToPIL(drw, dpi=dpi)
    plt.figure(dpi)
    plt.imshow(np.array(pil))
plt.show()
`

This generated the following output:
![image](https://user-images.githubusercontent.com/350050/38487612-650b040c-3c13-11e8-9e2a-ad8f3b0cad4b.png)

Output after fix:
![image](https://user-images.githubusercontent.com/350050/38487858-3208db50-3c14-11e8-8b48-0e323648925d.png)

I am sure that there is a better way ... such as incorporating d.renderScale (in renderScaledDrawing) right