### PR TITLE
Replace insecure MD5 hash with SHA-256 for PDF signature generation

### DIFF
--- a/src/reportlab/pdfbase/pdfdoc.py
+++ b/src/reportlab/pdfbase/pdfdoc.py
@@ -21,7 +21,7 @@ from reportlab import rl_config
 from reportlab.lib.utils import import_zlib, open_for_read, makeFileName, isSeq, isBytes, isUnicode, _digester, isStr, bytestr, isPy3, annotateException
 from reportlab.lib.rl_accel import escapePDF, fp_str, asciiBase85Encode, asciiBase85Decode
 from reportlab.pdfbase import pdfmetrics
-from hashlib import md5
+from hashlib import md5,sha256
 
 from sys import platform
 from sys import version_info
@@ -146,7 +146,7 @@ class PDFDocument(PDFObject):
         self.setCompression(compression)
         self._pdfVersion = pdfVersion
         # signature for creating PDF ID
-        sig = self.signature = md5()
+        sig = self.signature = sha256()
         sig.update(b"a reportlab document")
         if not self.invariant:
             cat = _getTimeStamp()


### PR DESCRIPTION
This PR replaces usage of the insecure md5 hashing algorithm with sha256 in pdfdoc.py.

MD5 is known to be cryptographically broken and is vulnerable to collision and pre-image attacks. Replacing it with SHA-256 aligns the library with modern security practices, especially when generating PDF identifiers and document signatures.